### PR TITLE
Add Support for Loading Rindow Matlib Library on macOS

### DIFF
--- a/src/MatlibFactory.php
+++ b/src/MatlibFactory.php
@@ -15,6 +15,8 @@ class MatlibFactory
 
     protected array $libs_win = ['rindowmatlib.dll'];
     protected array $libs_linux = ['librindowmatlib.so'];
+    protected array $libs_mac = ['librindowmatlib.dylib', '/usr/local/lib/librindowmatlib.dylib', '/usr/lib/librindowmatlib.dylib'];
+
     protected ?string $error = null;
 
     public function __construct(
@@ -32,7 +34,10 @@ class MatlibFactory
         if($libFiles==null) {
             if(PHP_OS=='Linux') {
                 $libFiles = $this->libs_linux;
-            } elseif(PHP_OS=='WINNT') {
+            } elseif(PHP_OS=='Darwin') {
+                $libFiles = $this->libs_mac;
+            }
+            elseif(PHP_OS=='WINNT') {
                 $libFiles = $this->libs_win;
             } else {
                 throw new RuntimeException('Unknown operating system: "'.PHP_OS.'"');


### PR DESCRIPTION
ThisPR introduces support for loading the Rindow Matlib library as a macOS shared library (.dylib) and using it in PHP via FFI. It depends on https://github.com/rindow/rindow-matlib/pull/1 and will remain open until that PR  is merged and released. This ensures that all changes are aligned and dependencies are properly resolved.

## Changes:
- Library Loading: Updated the rindow-matlib-ffi library to support loading the macOS shared library. (.dylib).
- PHP Tests: Ran the included tests in the library with the macOS library, and all tests passed successfully. Here's a screenshot of the test results:

  <img width="913" alt="image" src="https://github.com/rindow/rindow-matlib-ffi/assets/48791154/354247fc-b1c1-43bd-b312-977d8708d910">

## Inquiry on OpenMP :

You mentioned an issue with OpenMP when running with PHP on Linux, thus having two shared libraries on linux. I would like to inquire if the tests in the repo can potentially trigger the issue. My recent tests with the OpenMP build on macOS passed without issues. If these tests confirm no issues, that means I can modify the open PR on the C library to build a single OpenMP library, similar to the Windows version.

Thank you for considering this pull request. Please let me know if there are any further adjustments or information required.